### PR TITLE
Add support for PKCE auth code flow

### DIFF
--- a/examples/audio_streaming.rs
+++ b/examples/audio_streaming.rs
@@ -151,7 +151,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("DASH playback info retrieved:");
             println!("  Audio Quality: {:?}", dash_info.audio_quality);
             println!("  Bit Depth: {:?} bits", dash_info.bit_depth);
-            println!("  Sample Rate: {} Hz", dash_info.sample_rate);
+            println!("  Sample Rate: {:?} Hz", dash_info.sample_rate);
             println!("  Manifest MIME Type: {}", dash_info.manifest_mime_type);
 
             // Decode the manifest (it's base64 encoded)

--- a/examples/authentication.rs
+++ b/examples/authentication.rs
@@ -18,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client_secret = "your_client_secret";
 
     let client = TidalClient::new(client_id.to_string()).with_authz_refresh_callback(|new_authz| {
-        println!("Tokens refreshed for user: {}", new_authz.user_id);
+        println!("Tokens refreshed for user: {}", new_authz.user_id.unwrap());
         // In a real application, you would save these tokens to persistent storage
         // For example: save_to_file(&new_authz);
     });
@@ -43,20 +43,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .authorize(&device_auth.device_code, client_secret)
         .await?;
 
+    let user = authz_token.clone().user.unwrap();
     println!("\nAuthentication successful!");
-    println!(
-        "User: {} ({})",
-        authz_token.user.username, authz_token.user.email
-    );
-    println!("Country: {}", authz_token.user.country_code);
-    println!("User ID: {}", authz_token.user.user_id);
+    println!("User: {} ({})", user.username, user.email);
+    println!("Country: {}", user.country_code);
+    println!("User ID: {}", user.user_id);
 
     // Get current tokens for saving
     if let Some(authz) = authz_token.authz() {
         println!("\nCurrent tokens:");
         println!("   Access token: {}...", &authz.access_token[..20]);
         println!("   Refresh token: {}...", &authz.refresh_token[..20]);
-        println!("   User ID: {}", authz.user_id);
+        println!("   User ID: {}", authz.user_id.unwrap());
         println!("   Country: {:?}", authz.country_code);
 
         // In a real application, you would save these tokens for later use

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,15 +15,18 @@ pub use track::*;
 use arc_swap::ArcSwapOption;
 use async_recursion::async_recursion;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use std::collections::HashMap;
 use std::fmt::Display;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use strum_macros::{AsRefStr, EnumString};
 use tokio::sync::{Semaphore, SemaphorePermit};
 use tokio::time::sleep;
+use url::Url;
 
 pub(crate) static TIDAL_AUTH_API_BASE_URL: &str = "https://auth.tidal.com/v1";
-pub(crate) static TIDAL_API_BASE_URL: &str = "https://api.tidal.com/v1";
+pub(crate) static TIDAL_LOGIN_API_BASE_URL: &str = "https://login.tidal.com";
+pub(crate) static TIDAL_API_BASE_URL: &str = "https://openapi.tidal.com/v2";
 const INITIAL_BACKOFF_MILLIS: u64 = 100;
 const DEFAULT_MAX_BACKOFF_MILLIS: u64 = 5_000;
 
@@ -124,7 +127,7 @@ pub struct AuthzToken {
     #[serde(rename = "access_token")]
     pub access_token: String,
     /// Name of the client application
-    pub client_name: String,
+    pub client_name: Option<String>,
     /// Token expiration time in seconds
     #[serde(rename = "expires_in")]
     pub expires_in: i64,
@@ -136,8 +139,8 @@ pub struct AuthzToken {
     /// Type of token (typically "Bearer")
     #[serde(rename = "token_type")]
     pub token_type: String,
-    /// User information
-    pub user: User,
+    /// User  information
+    pub user: Option<User>,
     /// User ID (same as user.user_id but as i64)
     #[serde(rename = "user_id")]
     pub user_id: i64,
@@ -146,11 +149,16 @@ pub struct AuthzToken {
 impl AuthzToken {
     pub fn authz(&self) -> Option<Authz> {
         if let Some(refresh_token) = self.refresh_token.clone() {
+            let country_code = match &self.user {
+                Some(u) => Some(u.country_code.clone()),
+                None => None,
+            };
+
             Some(Authz {
                 access_token: self.access_token.clone(),
                 refresh_token: refresh_token,
-                user_id: self.user_id as u64,
-                country_code: Some(self.user.country_code.clone()),
+                user_id: Some(self.user_id as u64),
+                country_code,
             })
         } else {
             None
@@ -348,7 +356,7 @@ pub struct Authz {
     /// Refresh token for obtaining new access tokens
     pub refresh_token: String,
     /// User ID associated with these tokens
-    pub user_id: u64,
+    pub user_id: Option<u64>,
     /// User's country code (affects content availability)
     pub country_code: Option<String>,
 }
@@ -363,7 +371,7 @@ impl Authz {
         Self {
             access_token,
             refresh_token,
-            user_id,
+            user_id: Some(user_id),
             country_code,
         }
     }
@@ -620,7 +628,7 @@ impl TidalClient {
     ///
     /// Returns `None` if the client is not authenticated.
     pub fn get_user_id(&self) -> Option<u64> {
-        self.get_authz().map(|authz| authz.user_id)
+        self.get_authz().map(|authz| authz.user_id)?
     }
 
     /// Set the country code for API requests.
@@ -746,16 +754,18 @@ impl TidalClient {
                     .do_request(reqwest::Method::POST, &url, Some(params), None)
                     .await?;
 
+                let country_code = match resp.user {
+                    Some(u) => Some(u.country_code),
+                    None => None,
+                };
+
                 let new_authz = Authz {
                     access_token: resp.access_token,
                     refresh_token: resp
                         .refresh_token
                         .unwrap_or_else(|| authz.refresh_token.clone()),
-                    user_id: resp.user.user_id,
-                    country_code: match &authz.country_code {
-                        Some(country_code) => Some(country_code.clone()),
-                        None => Some(resp.user.country_code.clone()),
-                    },
+                    user_id: Some(resp.user_id as u64),
+                    country_code: country_code,
                 };
 
                 // Single, quick swap visible to all readers
@@ -1034,6 +1044,72 @@ impl TidalClient {
         Ok(resp)
     }
 
+    pub fn get_authorize_url(
+        &self,
+        redirect_uri: &str,
+        scopes: &str,
+        code_challenge: &str,
+        state: Option<&str>,
+    ) -> Result<String, Error> {
+        let login_url = format!("{TIDAL_LOGIN_API_BASE_URL}/authorize");
+
+        let mut payload: HashMap<&str, &str> = HashMap::new();
+        payload.insert("response_type", "code");
+        payload.insert("client_id", self.client_id.as_str());
+        payload.insert("redirect_uri", redirect_uri);
+        payload.insert("scope", scopes);
+        payload.insert("code_challenge", code_challenge);
+        payload.insert("code_challenge_method", "S256");
+        payload.insert("state", state.unwrap_or(""));
+
+        match Url::parse_with_params(login_url.as_str(), payload) {
+            Ok(u) => Ok(String::from(u.as_str())),
+            Err(_) => Err(Error::NoPrimaryUrl),
+        }
+    }
+
+    pub async fn pkce_authorize(
+        &self,
+        code: &str,
+        redirect_uri: &str,
+        code_verifier: &str,
+        scopes: &str,
+    ) -> Result<AuthzToken, Error> {
+        let url = format!("{TIDAL_AUTH_API_BASE_URL}/oauth2/token");
+
+        let params = serde_json::json!({
+            "client_id": &self.client_id,
+            "code_verifier": code_verifier,
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": redirect_uri,
+            "scope": scopes
+        });
+
+        let resp: AuthzToken = self
+            .do_request(reqwest::Method::POST, &url, Some(params), None)
+            .await?;
+
+        let country_code = match &resp.user {
+            Some(u) => Some(u.country_code.clone()),
+            None => None,
+        };
+
+        let authz = Authz {
+            access_token: resp.access_token.clone(),
+            refresh_token: resp
+                .refresh_token
+                .clone()
+                .expect("No refresh token received from Tidal after authorization"),
+            user_id: Some(resp.user_id as u64),
+            country_code,
+        };
+
+        self.authz.store(Some(Arc::new(authz)));
+
+        Ok(resp)
+    }
+
     /// Complete the OAuth2 device authorization flow.
     ///
     /// Call this method after the user has visited the authorization URL and
@@ -1083,17 +1159,19 @@ impl TidalClient {
             .do_request(reqwest::Method::POST, &url, Some(params), None)
             .await?;
 
+        let country_code = match &resp.user {
+            Some(u) => Some(u.country_code.clone()),
+            None => None,
+        };
+
         let authz = Authz {
             access_token: resp.access_token.clone(),
             refresh_token: resp
                 .refresh_token
                 .clone()
                 .expect("No refresh token received from Tidal after authorization"),
-            user_id: resp.user.user_id,
-            country_code: match &self.country_code {
-                Some(country_code) => Some(country_code.clone()),
-                None => Some(resp.user.country_code.clone()),
-            },
+            user_id: Some(resp.user_id as u64),
+            country_code,
         };
 
         self.authz.store(Some(Arc::new(authz)));

--- a/tests/builder_pattern.rs
+++ b/tests/builder_pattern.rs
@@ -65,7 +65,7 @@ fn test_builder_pattern_with_authz() {
     if let Some(stored_authz) = client.get_authz() {
         assert_eq!(stored_authz.access_token, "test_access_token");
         assert_eq!(stored_authz.refresh_token, "test_refresh_token");
-        assert_eq!(stored_authz.user_id, 12345);
+        assert_eq!(stored_authz.user_id, Some(12345));
         assert_eq!(stored_authz.country_code, Some("CA".to_string()));
     } else {
         panic!("Authz should be stored in client");
@@ -119,7 +119,7 @@ fn test_builder_pattern_chaining() {
 
     // Verify authz is stored
     if let Some(stored_authz) = client.get_authz() {
-        assert_eq!(stored_authz.user_id, 67890);
+        assert_eq!(stored_authz.user_id, Some(67890));
         assert_eq!(stored_authz.country_code, Some("AU".to_string()));
     } else {
         panic!("Authz should be stored in client");


### PR DESCRIPTION
TIDAL API has added support for using OAuth 2 auth code with PKCE:
https://developer.tidal.com/documentation/api-sdk/api-sdk-authorization

this adds 2 methods to TidalClient to support this flow, along with some slight changes to structs to account for different responses from this flow vs. device code.