### PR TITLE
Feat/authorization pending error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,6 +96,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +197,15 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "combine"
@@ -467,6 +486,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +557,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -528,9 +572,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -872,6 +918,31 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "mockito"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90820618712cab19cfc46b274c6c22546a82affcb3c3bdf0f29e3db8e1bb92c0"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "pin-project-lite",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -1520,6 +1591,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +1908,7 @@ dependencies = [
  "base64",
  "env_logger",
  "log",
+ "mockito",
  "reqwest",
  "rodio",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,4 @@ tokio = { version = "1.0", features = ["full"] }
 env_logger = "0.11"
 serde_json = "1.0"
 rodio = "0.21"
+mockito = "1"

--- a/examples/audio_streaming.rs
+++ b/examples/audio_streaming.rs
@@ -151,7 +151,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             println!("DASH playback info retrieved:");
             println!("  Audio Quality: {:?}", dash_info.audio_quality);
             println!("  Bit Depth: {:?} bits", dash_info.bit_depth);
-            println!("  Sample Rate: {} Hz", dash_info.sample_rate);
+            println!("  Sample Rate: {:?} Hz", dash_info.sample_rate);
             println!("  Manifest MIME Type: {}", dash_info.manifest_mime_type);
 
             // Decode the manifest (it's base64 encoded)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,6 +262,14 @@ pub enum Error {
     /// Exponential backoff exceeded the maximum duration while handling rate limits
     #[error("Hit rate limit backoff ceiling of {0}ms without recovery")]
     RateLimitBackoffExceeded(u64),
+    /// OAuth2 device flow: user has not yet completed browser authorization.
+    ///
+    /// This is returned by [`TidalClient::authorize`] while polling during the
+    /// device authorization flow. The caller should wait (typically 5 seconds)
+    /// and retry. Polling should stop once [`DeviceAuthorizationResponse::expires_in`]
+    /// seconds have elapsed.
+    #[error("Authorization pending — user has not yet completed browser authentication")]
+    AuthorizationPending,
 }
 
 /// Callback function type for handling authorization token refresh events.
@@ -901,6 +909,16 @@ impl TidalClient {
                 }
             } else {
                 self.reset_rate_limit_backoff();
+            }
+
+            // The OAuth2 device flow token endpoint returns a different error schema
+            // from TIDAL's API endpoints: {"error": "authorization_pending", ...} (RFC 8628).
+            // Detect this before the generic TidalApiError parse, which would silently
+            // discard the "error" field due to schema mismatch.
+            if status.as_u16() == 400 {
+                if let Some("authorization_pending") = value.get("error").and_then(|v| v.as_str()) {
+                    return Err(Error::AuthorizationPending);
+                }
             }
 
             let tidal_err = match serde_json::from_value::<TidalApiError>(value.clone()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,16 +145,12 @@ pub struct AuthzToken {
 
 impl AuthzToken {
     pub fn authz(&self) -> Option<Authz> {
-        if let Some(refresh_token) = self.refresh_token.clone() {
-            Some(Authz {
-                access_token: self.access_token.clone(),
-                refresh_token: refresh_token,
-                user_id: self.user_id as u64,
-                country_code: Some(self.user.country_code.clone()),
-            })
-        } else {
-            None
-        }
+        self.refresh_token.clone().map(|refresh_token| Authz {
+            access_token: self.access_token.clone(),
+            refresh_token,
+            user_id: self.user_id as u64,
+            country_code: Some(self.user.country_code.clone()),
+        })
     }
 }
 
@@ -316,6 +312,7 @@ pub type AuthzCallback = Arc<dyn Fn(Authz) + Send + Sync>;
 pub struct TidalClient {
     pub client: reqwest::Client,
     client_id: String,
+    auth_base_url: String,
     authz: ArcSwapOption<Authz>,
     authz_update_semaphore: Semaphore,
     country_code: Option<String>,
@@ -395,6 +392,7 @@ impl TidalClient {
         Self {
             client: reqwest::Client::new(),
             client_id,
+            auth_base_url: TIDAL_AUTH_API_BASE_URL.to_string(),
             authz: ArcSwapOption::from(None),
             authz_update_semaphore: Semaphore::new(1),
             country_code: None,
@@ -404,6 +402,25 @@ impl TidalClient {
             backoff: Mutex::new(None),
             max_backoff_millis: None,
         }
+    }
+
+    /// Override the authentication base URL.
+    ///
+    /// The default is `https://auth.tidal.com/v1`. Override this to point at a
+    /// staging environment, a local mock server during testing, or a compatible
+    /// proxy. Affects `device_authorization()`, `authorize()`, and token refresh.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use tidalrs::TidalClient;
+    ///
+    /// let client = TidalClient::new("client_id".to_string())
+    ///     .with_auth_base_url("http://localhost:1234".to_string());
+    /// ```
+    pub fn with_auth_base_url(mut self, url: String) -> Self {
+        self.auth_base_url = url;
+        self
     }
 
     /// Set a custom HTTP client using the builder pattern.
@@ -739,7 +756,7 @@ impl TidalClient {
         match permit {
             // We're the single refresher, fetch the new authz and update the client
             Some(permit) => {
-                let url = format!("{TIDAL_AUTH_API_BASE_URL}/oauth2/token");
+                let url = format!("{}/oauth2/token", self.auth_base_url);
 
                 let authz = self.get_authz().ok_or(Error::NoAuthzToken)?;
 
@@ -915,10 +932,10 @@ impl TidalClient {
             // from TIDAL's API endpoints: {"error": "authorization_pending", ...} (RFC 8628).
             // Detect this before the generic TidalApiError parse, which would silently
             // discard the "error" field due to schema mismatch.
-            if status.as_u16() == 400 {
-                if let Some("authorization_pending") = value.get("error").and_then(|v| v.as_str()) {
-                    return Err(Error::AuthorizationPending);
-                }
+            if status.as_u16() == 400
+                && let Some("authorization_pending") = value.get("error").and_then(|v| v.as_str())
+            {
+                return Err(Error::AuthorizationPending);
             }
 
             let tidal_err = match serde_json::from_value::<TidalApiError>(value.clone()) {
@@ -1036,7 +1053,7 @@ impl TidalClient {
     /// # }
     /// ```
     pub async fn device_authorization(&self) -> Result<DeviceAuthorizationResponse, Error> {
-        let url = format!("{TIDAL_AUTH_API_BASE_URL}/oauth2/device_authorization");
+        let url = format!("{}/oauth2/device_authorization", self.auth_base_url);
 
         let params = serde_json::json!({
             "client_id": &self.client_id,
@@ -1087,7 +1104,7 @@ impl TidalClient {
         device_code: &str,
         client_secret: &str,
     ) -> Result<AuthzToken, Error> {
-        let url = format!("{TIDAL_AUTH_API_BASE_URL}/oauth2/token");
+        let url = format!("{}/oauth2/token", self.auth_base_url);
 
         let params = serde_json::json!({
             "client_id": &self.client_id,

--- a/tests/device_flow.rs
+++ b/tests/device_flow.rs
@@ -1,0 +1,124 @@
+//! Integration tests for the OAuth2 device authorization flow.
+//!
+//! These tests use `mockito` to stand up a local HTTP server in place of
+//! `https://auth.tidal.com/v1`, exercising `do_request`'s error-discrimination
+//! logic end-to-end without real network calls.
+
+use tidalrs::{Error, TidalClient};
+
+/// Build a test client pointed at a mockito server instead of TIDAL's auth endpoint.
+fn test_client(server_url: &str) -> TidalClient {
+    TidalClient::new("test_client_id".to_string())
+        .with_auth_base_url(server_url.to_string())
+}
+
+// ─── AuthorizationPending ────────────────────────────────────────────────────
+
+/// TIDAL returns `{"error": "authorization_pending", ...}` (RFC 8628 §3.5)
+/// while the user hasn't yet completed browser auth. This should produce
+/// `Error::AuthorizationPending`, not a generic `TidalApiError { status: 400 }`.
+#[tokio::test]
+async fn test_authorize_returns_authorization_pending() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mock = server
+        .mock("POST", "/oauth2/token")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error":"authorization_pending","error_description":"The authorization request is still pending"}"#)
+        .create_async()
+        .await;
+
+    let client = test_client(&server.url());
+    let result = client.authorize("device_code", "client_secret").await;
+
+    mock.assert_async().await;
+    assert!(
+        matches!(result, Err(Error::AuthorizationPending)),
+        "expected AuthorizationPending, got: {:?}",
+        result
+    );
+}
+
+/// Ensure `AuthorizationPending` is distinct from a generic TIDAL API error
+/// that also returns 400 (e.g. invalid client credentials).
+#[tokio::test]
+async fn test_other_400_is_not_authorization_pending() {
+    let mut server = mockito::Server::new_async().await;
+
+    let mock = server
+        .mock("POST", "/oauth2/token")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"status":400,"subStatus":1001,"userMessage":"Invalid client credentials"}"#)
+        .create_async()
+        .await;
+
+    let client = test_client(&server.url());
+    let result = client.authorize("device_code", "bad_secret").await;
+
+    mock.assert_async().await;
+    assert!(
+        matches!(result, Err(Error::TidalApiError(_))),
+        "expected TidalApiError for a non-pending 400, got: {:?}",
+        result
+    );
+    assert!(
+        !matches!(result, Err(Error::AuthorizationPending)),
+        "a non-pending 400 must not be AuthorizationPending"
+    );
+}
+
+/// Verify the error message is human-readable and contains meaningful text.
+#[test]
+fn test_authorization_pending_display() {
+    let err = Error::AuthorizationPending;
+    let msg = err.to_string();
+    assert!(
+        msg.contains("pending") || msg.contains("Authorization"),
+        "error message should describe the pending state, got: {msg}"
+    );
+}
+
+// ─── YOUR CONTRIBUTION ───────────────────────────────────────────────────────
+//
+// Implement `test_polling_loop_succeeds_after_pending`.
+//
+// This test verifies that a caller who retries `authorize()` after receiving
+// `AuthorizationPending` eventually gets `Ok(AuthzToken)` on success.
+//
+// Set up two mock responses on the same endpoint (mockito supports sequenced
+// responses with `.with_body()` chained or separate `.mock()` calls with
+// `expect(1)`):
+//   1. First call  → 400 {"error":"authorization_pending","error_description":"..."}
+//   2. Second call → 200 with a valid AuthzToken JSON body
+//
+// A minimal valid AuthzToken body (fill in the fields `authorize()` needs):
+//
+//   {
+//     "access_token": "test_access",
+//     "client_name": "test",
+//     "expires_in": 3600,
+//     "refresh_token": "test_refresh",
+//     "scope": "r_usr w_usr w_sub",
+//     "token_type": "Bearer",
+//     "user": {
+//       "accepted_eula": true, "account_link_created": false,
+//       "channel_id": 1, "country_code": "US", "created": 0,
+//       "email": "test@example.com", "email_verified": true,
+//       "new_user": false, "parent_id": 0, "updated": 0,
+//       "user_id": 12345, "username": "testuser"
+//     },
+//     "user_id": 12345
+//   }
+//
+// Then write a small loop:
+//   loop {
+//     match client.authorize("device_code", "client_secret").await {
+//       Ok(token)                        => { assert_eq!(...); break; }
+//       Err(Error::AuthorizationPending) => { /* retry */ }
+//       Err(e)                           => panic!("unexpected: {e}"),
+//     }
+//   }
+//
+// ─────────────────────────────────────────────────────────────────────────────

--- a/tests/device_flow.rs
+++ b/tests/device_flow.rs
@@ -4,12 +4,13 @@
 //! `https://auth.tidal.com/v1`, exercising `do_request`'s error-discrimination
 //! logic end-to-end without real network calls.
 
+use std::time::Duration;
+
 use tidalrs::{Error, TidalClient};
 
 /// Build a test client pointed at a mockito server instead of TIDAL's auth endpoint.
 fn test_client(server_url: &str) -> TidalClient {
-    TidalClient::new("test_client_id".to_string())
-        .with_auth_base_url(server_url.to_string())
+    TidalClient::new("test_client_id".to_string()).with_auth_base_url(server_url.to_string())
 }
 
 // ─── AuthorizationPending ────────────────────────────────────────────────────
@@ -80,45 +81,73 @@ fn test_authorization_pending_display() {
     );
 }
 
-// ─── YOUR CONTRIBUTION ───────────────────────────────────────────────────────
-//
-// Implement `test_polling_loop_succeeds_after_pending`.
-//
-// This test verifies that a caller who retries `authorize()` after receiving
-// `AuthorizationPending` eventually gets `Ok(AuthzToken)` on success.
-//
-// Set up two mock responses on the same endpoint (mockito supports sequenced
-// responses with `.with_body()` chained or separate `.mock()` calls with
-// `expect(1)`):
-//   1. First call  → 400 {"error":"authorization_pending","error_description":"..."}
-//   2. Second call → 200 with a valid AuthzToken JSON body
-//
-// A minimal valid AuthzToken body (fill in the fields `authorize()` needs):
-//
-//   {
-//     "access_token": "test_access",
-//     "client_name": "test",
-//     "expires_in": 3600,
-//     "refresh_token": "test_refresh",
-//     "scope": "r_usr w_usr w_sub",
-//     "token_type": "Bearer",
-//     "user": {
-//       "accepted_eula": true, "account_link_created": false,
-//       "channel_id": 1, "country_code": "US", "created": 0,
-//       "email": "test@example.com", "email_verified": true,
-//       "new_user": false, "parent_id": 0, "updated": 0,
-//       "user_id": 12345, "username": "testuser"
-//     },
-//     "user_id": 12345
-//   }
-//
-// Then write a small loop:
-//   loop {
-//     match client.authorize("device_code", "client_secret").await {
-//       Ok(token)                        => { assert_eq!(...); break; }
-//       Err(Error::AuthorizationPending) => { /* retry */ }
-//       Err(e)                           => panic!("unexpected: {e}"),
-//     }
-//   }
-//
-// ─────────────────────────────────────────────────────────────────────────────
+#[tokio::test]
+async fn test_polling_loop_succeeds_after_pending() {
+    // AuthzToken uses explicit rename for some fields, camelCase for others.
+    // Fields with #[serde(rename = "...")] keep their literal name;
+    // the rest follow rename_all = "camelCase" on the struct.
+    let authz_token_body = r#"{
+        "access_token": "some_token",
+        "clientName": "some_client",
+        "expires_in": 4444,
+        "refresh_token": "some_refresh",
+        "scope": "r_usr w_usr w_sub",
+        "token_type": "Bearer",
+        "user": {
+            "acceptedEULA": true,
+            "accountLinkCreated": false,
+            "channelId": 1,
+            "countryCode": "CA",
+            "created": 0,
+            "email": "null@example.com",
+            "emailVerified": true,
+            "newUser": false,
+            "parentId": 0,
+            "updated": 0,
+            "userId": 8675309,
+            "username": "someuser"
+        },
+        "user_id": 8675309
+    }"#;
+
+    let mut server = mockito::Server::new_async().await;
+
+    let mock_pending = server
+        .mock("POST", "/oauth2/token")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error":"authorization_pending","error_description":"The authorization request is still pending"}"#)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let mock_success = server
+        .mock("POST", "/oauth2/token")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(authz_token_body)
+        .expect(1)
+        .create_async()
+        .await;
+
+    let client = test_client(&server.url());
+    loop {
+        match client.authorize("device_code", "client_secret").await {
+            Ok(token) => {
+                assert_eq!(token.access_token, "some_token");
+                assert_eq!(token.expires_in, 4444);
+                assert_eq!(token.user.user_id, 8675309);
+                assert_eq!(token.user.country_code, "CA");
+                break;
+            }
+            Err(Error::AuthorizationPending) => {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                continue;
+            }
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    }
+
+    mock_pending.assert_async().await;
+    mock_success.assert_async().await;
+}


### PR DESCRIPTION
# Add `Error::AuthorizationPending` for OAuth2 device flow polling

## Problem

During the device authorization flow (RFC 8628), TIDAL's token endpoint
returns a distinct JSON schema while the user hasn't yet completed browser
authentication:

```json
{"error": "authorization_pending", "error_description": "..."}
```

Previously, `do_request` parsed all non-2xx responses as `TidalApiError`,
so this response was silently coerced into:

```rust
TidalApiError { status: 400, sub_status: 0, user_message: "" }
```

Callers polling `authorize()` had to match on the raw status code with no
type safety, and could not distinguish "still waiting" from a real error
like invalid credentials (which also returns 400).

## Changes

**`src/lib.rs`**
- Add `Error::AuthorizationPending` variant (with doc comment referencing
  `DeviceAuthorizationResponse` and `TidalClient::authorize`)
- In `do_request()`, detect `{"error": "authorization_pending"}` on 400
  responses *before* the `TidalApiError` parse

**`src/lib.rs` (TidalClient)**
- Add `auth_base_url: String` field (defaults to `TIDAL_AUTH_API_BASE_URL`),
  replacing three hardcoded string usages
- Add `with_auth_base_url(url: String)` builder method for redirecting auth
  requests in tests and non-production environments

**`tests/device_flow.rs`** (new file, using `mockito`)
- `test_authorize_returns_authorization_pending` — RFC 8628 body → `Error::AuthorizationPending`
- `test_other_400_is_not_authorization_pending` — TIDAL API 400 body → `Error::TidalApiError` (no false positives)
- `test_authorization_pending_display` — error message sanity check
- `test_polling_loop_succeeds_after_pending` — full polling loop: pending on
  first call, success token on second

## After this change

Callers can now write a clean, type-safe polling loop:

```rust
loop {
    match client.authorize(&device_code, &client_secret).await {
        Ok(token)                        => { /* authenticated */ break; }
        Err(Error::AuthorizationPending) => { sleep(interval).await; continue; }
        Err(e)                           => return Err(e),
    }
}
```
